### PR TITLE
Update CI workflow conditions for PyPI and TestPyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    if: github.ref == 'refs/heads/develop' || github.event_name == 'push'
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -112,9 +112,9 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish distribution 📦 to PyPI
+      - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://pypi.org/legacy/
 
 


### PR DESCRIPTION
Changed publish conditions to trigger only on specific branch and event combinations and adjusted the repository URL for the PyPI publish step. This ensures the publishing process is more controlled and follows the intended workflow criteria.