### PR TITLE
Update PyPI repository URL and bump version to 0.0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,6 @@ jobs:
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://pypi.org/legacy/
+          repository-url: https://upload.pypi.org/legacy/
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup, find_packages
 
 DESCRIPTION = "Manage email templates in DB with django"
-VERSION = "0.0.9"
+VERSION = "0.0.10"
 LONG_DESCRIPTION = None
 try:
     LONG_DESCRIPTION = open("README.md").read()


### PR DESCRIPTION
Changed the repository URL in the CI workflow from pypi.org to upload.pypi.org for publishing distributions. Increased the package version in setup.py from 0.0.9 to 0.0.10 to reflect these changes.