### PR TITLE
Update mail template retrieval and bump version

### DIFF
--- a/django_mail_model_template/utils.py
+++ b/django_mail_model_template/utils.py
@@ -5,7 +5,7 @@ from django.template import Context, Template
 
 
 def get_mail_template(name: str, params: Dict[str, Any]) -> Dict[str, str]:
-    mail_template = MailTemplate.objects.get(name="main")
+    mail_template = MailTemplate.objects.get(name=name)
     context = Context(params)
     return {
         "name": mail_template.name,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup, find_packages
 
 DESCRIPTION = "Manage email templates in DB with django"
-VERSION = "0.0.10"
+VERSION = "0.0.11"
 LONG_DESCRIPTION = None
 try:
     LONG_DESCRIPTION = open("README.md").read()


### PR DESCRIPTION
Changed the mail template retrieval to use dynamic name input instead of a hard-coded value in utils.py. Bumped the package version in setup.py to 0.0.11.